### PR TITLE
get_identified_elements() will now always return pronouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Download the required spaCy model:
 python -m spacy download en_core_web_trf
 ```
 
-For debugging, by setting `config.debug=True`, you will also need [VeryPrettyTable](https://github.com/smeggingsmegger/):
-```bash
-pip install VeryPrettyTable
-```
-
 ## Usage
 
 ### Command Line Interface
@@ -41,6 +36,8 @@ pip install VeryPrettyTable
 The package includes a command-line tool for quick de-identification of text files:
 
 ```bash
+deidentify input_file [options]
+# or:
 python -m deidentification.deidentify input_file [options]
 ```
 
@@ -55,7 +52,7 @@ Options:
 Example:
 ```bash
 # De-identify a text file and save with HTML markup
-python -m deidentification.deidentify input.txt -H -o output.html -r "[REDACTED]"
+deidentify input.txt -H -o output.html -r "[REDACTED]"
 ```
 
 ### Python API Usage

--- a/deidentification/deidentification.py
+++ b/deidentification/deidentification.py
@@ -69,6 +69,9 @@ class Deidentification:
         # this combines all self.all_persons lists from multiple passes of self._find_all_persons()
         self.aggregate_persons: list[dict] = []
 
+        # this combines all self.all_pronouns lists from multiple loop iterations in self.deidentify()
+        self.aggregate_pronouns: list[dict] = []
+
         self.all_pronouns: list[dict] = []
         self.doc: Optional[Doc] = None
         self.table_class  = None
@@ -139,6 +142,7 @@ class Deidentification:
                 self.__debug_log(f"deidentify(): next iter, persons={len(self.all_persons)}")
             if persons_count == 0:
                 break
+            self.aggregate_pronouns.extend(self.all_pronouns)
             self.all_pronouns = []
             merged = self._merge_metadata()
             replaced_text = self._replace_merged(replaced_text, merged)
@@ -167,7 +171,7 @@ class Deidentification:
         return buffer.getvalue()
 
     def get_identified_elements(self) -> dict:
-        elements = {"message": self.replaced_text, "entities": self.aggregate_persons, "pronouns": self.all_pronouns}
+        elements = {"message": self.replaced_text, "entities": self.aggregate_persons, "pronouns": self.aggregate_pronouns}
         return elements
 
     def _find_all_persons(self) -> int:

--- a/deidentification/deidentification_constants.py
+++ b/deidentification/deidentification_constants.py
@@ -1,6 +1,6 @@
 pgmName = "deidentification"
 pgmUrl = "https://github.com/jftuga/deidentification"
-pgmVersion = "1.1.1"
+pgmVersion = "1.1.2"
 
 GENDER_PRONOUNS = {
     "he": "HE/SHE",


### PR DESCRIPTION
* If multiple passes were needed in `deidentify()`, then `get_identified_elements()` would not have returned any pronouns.
* also included small refinements to `README.md`
