### PR TITLE
allow for multiple languages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ clean:
 	rm -rf dist/
 	rm -rf *.egg-info/
 	rm -rf $(VENV_NAME)/
-	rm -rf __pycache__/
 	rm -rf test-install-venv/
 	rm -f *.whl.metadata .??*~
 	find . -type d -name "__pycache__" -exec rm -r "{}" +

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0cb8675d847b9e71d9627d316dd6ea598529ec09ee23c28ae199fdf340aa9a88"
+            "sha256": "fea334d60198a4446c6cce376206b176b9e47c97ec9ba72e1cd174808be3376b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1120,28 +1120,28 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:03a90200c5dfff49e4c967b405f27fdfa81594cbb7c5ff5609e42d7fe9680da5",
-                "sha256:1098d36f69831f7ff2a1da3e6407d5fbd6dfa2559e4f74ff2d260c5588900317",
-                "sha256:134ae019ef13e1b060ab7136e7828a6d83ea727ba123381307eb37c6bd5e01cb",
-                "sha256:4020d8bf8d3a32325c77af452a9976a9ad6455773bcb94991cf15bd66b347e47",
-                "sha256:587c5e95007612c26509f30acc506c874dab4c4abbacd0357400bd1aa799931b",
-                "sha256:5ad11a5e3868a73ca1fa4727fe7e33735ea78b416313f4368c504dbeb69c0f88",
-                "sha256:622b82bf3429ff0e346835ec213aec0a04d9730480cbffbb6ad9372014e31bbd",
-                "sha256:7512e8cb038db7f5db6aae0e24735ff9ea03bb0ed6ae2ce534e9baa23c1dc9ea",
-                "sha256:762f113232acd5b768d6b875d16aad6b00082add40ec91c927f0673a8ec4ede8",
-                "sha256:7b75ac29715ac60d554a049dbb0ef3b55259076181c3369d79466cb130eb5afd",
-                "sha256:8710ffd57bdaa6690cbf6ecff19884b8629ec2a2a2a2f783aa94b1cc795139ed",
-                "sha256:9d99cf80b0429cbebf31cbbf6f24f05a29706f0437c40413d950e67e2d4faca4",
-                "sha256:b5462d7804558ccff9c08fe8cbf6c14b7efe67404316696a2dde48297b1925bb",
-                "sha256:c01c048f9c3385e0fd7822ad0fd519afb282af9cf1778f3580e540629df89725",
-                "sha256:c9d526a62c9eda211b38463528768fd0ada25dad524cb33c0e99fcff1c67b5dc",
-                "sha256:d56de7220a35607f9fe59f8a6d018e14504f7b71d784d980835e20fc0611cd50",
-                "sha256:f69ab37771ea7e0715fead8624ec42996d101269a96e31f4d31be6fc33aa19b7",
-                "sha256:f99be814d77a5dac8a8957104bdd8c359e85c86b0ee0e38dca447cb1095f70fb"
+                "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25",
+                "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe",
+                "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75",
+                "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a",
+                "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76",
+                "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188",
+                "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1",
+                "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf",
+                "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117",
+                "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162",
+                "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d",
+                "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d",
+                "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315",
+                "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5",
+                "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3",
+                "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764",
+                "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807",
+                "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.8.5"
+            "version": "==0.8.6"
         }
     }
 }

--- a/deidentification/__init__.py
+++ b/deidentification/__init__.py
@@ -1,6 +1,6 @@
 """A Python module for de-identifying personally identifiable information in text."""
 
-from .deidentification import Deidentification, DeidentificationConfig, DeidentificationOutputStyle
+from .deidentification import Deidentification, DeidentificationConfig, DeidentificationOutputStyle, DeidentificationLanguages
 from .deidentification_constants import pgmName, pgmVersion, pgmUrl
 
 __version__ = pgmVersion
@@ -9,6 +9,7 @@ __all__ = [
     "Deidentification",
     "DeidentificationConfig",
     "DeidentificationOutputStyle",
+    "DeidentificationLanguages",
     "pgmName",
     "pgmVersion",
     "pgmUrl",

--- a/deidentification/deidentification_constants.py
+++ b/deidentification/deidentification_constants.py
@@ -1,8 +1,19 @@
+from enum import Enum
+
 pgmName = "deidentification"
 pgmUrl = "https://github.com/jftuga/deidentification"
 pgmVersion = "1.2.1"
 
-GENDER_PRONOUNS = {
+# the maps the default replacement word for each language
+class DeidentificationLanguages(Enum):
+    ENGLISH = "PERSON"
+
+class DeidentificationOutputStyle(Enum):
+    TEXT = "text"
+    HTML = "html"
+
+GENDER_PRONOUNS = {}
+GENDER_PRONOUNS[DeidentificationLanguages.ENGLISH] = {
     "he": "HE/SHE",
     "him": "HIM/HER",
     "his": "HIS/HER",


### PR DESCRIPTION
* allow for multiple languages in the future by making `GENDER_PRONOUNS` a dict which uses the `DeidentificationLanguages` Enum-style class as keys
* moved helper classes to `deidentification_constants.py` to avoid a circular dependency
* `DeidentificationLanguages` now maps the default `DeidentificationConfig.replacement` word to a language-specific noun, such as `PERSON`